### PR TITLE
Auto release python package on merge to master

### DIFF
--- a/.github/workflows/push_empiric_publisher.yaml
+++ b/.github/workflows/push_empiric_publisher.yaml
@@ -1,11 +1,11 @@
-name: Push Empiric Publisher Docker Image
+name: Publish Empiric Package
 on:
   push:
     branches:
       - master
 
 jobs:
-  push_empiric_publisher:
+  publish:
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -16,7 +16,15 @@ jobs:
       - uses: satackey/action-docker-layer-caching@v0.0.11
         continue-on-error: true
 
-      - name: Build and publish image
+      - name: Build and publish Python package
+        env:
+          PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          cd empiric-package
+          python3 -m build
+          twine upload dist/* -u __token__ -p $PYPI_API_TOKEN
+
+      - name: Build and publish Docker image
         env:
           DOCKER_ACCESS_TOKEN: ${{ secrets.DOCKER_ACCESS_TOKEN }}
         run: |

--- a/README.md
+++ b/README.md
@@ -100,11 +100,9 @@ Then, depending on which contracts were redeployed, you have to take further ste
 - Finally, if the Oracle Controller is updated, you'll have to update the address in empiric-package (`empiric.core.const`), in this README (above), in the sample consumer (`contracts/sample_consumer/SampleConsumer.cairo`) and in empiric-ui (`src/services/address.service.ts`). Then you'll have to follow the release processes for those components. Finally, make sure to coordinate with protocols to update their references.
 
 ## Empiric Package
-First, make sure to set the environmental variable `PYPI_API_TOKEN`.
+To create a new version, just navigate into `empiric-package` and run `bumpversion <part>` (where `<part>` is major, minor or patch). Make sure to run `git push --tags` once you've done that.
 
-To create a new version, just navigate into `empiric-package` and run `bumpversion <part>` (where `<part>` is major, minor or patch). Then run `python3 -m build` to generate the distribution archives. Finally upload the new distribution with `twine upload dist/* -u __token__ -p $PYPI_API_TOKEN`. Make sure to run `git push --tags` once you've done that.
-
-When you merge to master, the Empiric Publisher GHA will automatically release a new Docker base image with the appropriate tag (the new version of the `empiric-network` package). See the "Empiric Publisher Docker Base Image" section for more details.
+This new version will be released automatically along with the Docker base image when a branch is merged to master.
 
 ## Empiric UI
 Netlify will automatically deploy previews on push if a pull request is open and will redeploy the main website on merge to master.


### PR DESCRIPTION
Will make our lives easier for the upcoming changes to the Python package. Suggesting to merge into config_refactor as that is the feature base branch for the recent group of changes afaik