### PR TITLE
Use nanosecond precision for nonce instead of seconds

### DIFF
--- a/empiric-package/empiric/core/base_client.py
+++ b/empiric-package/empiric/core/base_client.py
@@ -14,7 +14,7 @@ from starkware.starknet.public.abi import get_selector_from_name
 
 class EmpiricAccountClient(AccountClient):
     async def _get_nonce(self) -> int:
-        return int(time.time())
+        return int(time.time_ns())
 
 
 class EmpiricBaseClient(ABC):


### PR DESCRIPTION
Use nanosecond precision to prevent nonce errors if multiple tx were generated within the same second. 

Related file : https://github.com/42labs/Empiric/blob/2169125341f527edcbcc9992d98bb656db03b90d/contracts/src/account/library.cairo#L150