### PR TITLE
Handle fetcher errors

### DIFF
--- a/empiric-package/empiric/core/entry.py
+++ b/empiric-package/empiric/core/entry.py
@@ -94,6 +94,9 @@ class GenericEntry(Entry):
             self.value,
         )
 
+    def __repr__(self):
+        return f'GenericEntry(key="{felt_to_str(self.key)}", value={self.value}, timestamp={self.base.timestamp}, source="{felt_to_str(self.base.source)}", publisher="{felt_to_str(self.base.publisher)}")'
+
 
 class SpotEntry(Entry):
     base: BaseEntry
@@ -192,7 +195,7 @@ class SpotEntry(Entry):
         return list(filter(lambda item: item is not None, serialized_entries))
 
     def __repr__(self):
-        return f'SpotEntry(pair_id="{felt_to_str(self.pair_id)}", price={self.price}, timestamp={self.timestamp}, source="{felt_to_str(self.source)}", publisher="{felt_to_str(self.publisher)}")'
+        return f'SpotEntry(pair_id="{felt_to_str(self.pair_id)}", price={self.price}, timestamp={self.base.timestamp}, source="{felt_to_str(self.base.source)}", publisher="{felt_to_str(self.base.publisher)}")'
 
 
 class FutureEntry(Entry):

--- a/empiric-package/empiric/publisher/client.py
+++ b/empiric-package/empiric/publisher/client.py
@@ -54,7 +54,7 @@ class EmpiricPublisherClient(EmpiricClient):
                 tasks.append(data)
             result = await asyncio.gather(*tasks, return_exceptions=True)
             if filter_exceptions:
-                return [val for subl in result for val in subl if not isinstance(result, Exception)]
+                return [val for subl in result for val in subl if not isinstance(val, Exception)]
             return [val for subl in result for val in subl]
 
     def fetch_sync(self) -> List[SpotEntry]:

--- a/empiric-package/empiric/publisher/client.py
+++ b/empiric-package/empiric/publisher/client.py
@@ -54,6 +54,13 @@ class EmpiricPublisherClient(EmpiricClient):
                 tasks.append(data)
             result = await asyncio.gather(*tasks, return_exceptions=True)
             if filter_exceptions:
+                for exception in [
+                    val
+                    for subl in result
+                    for val in subl
+                    if isinstance(val, Exception)
+                ]:
+                    log.warn(f'Fetch Error: {exception}')
                 return [
                     val
                     for subl in result

--- a/empiric-package/empiric/publisher/client.py
+++ b/empiric-package/empiric/publisher/client.py
@@ -54,7 +54,12 @@ class EmpiricPublisherClient(EmpiricClient):
                 tasks.append(data)
             result = await asyncio.gather(*tasks, return_exceptions=True)
             if filter_exceptions:
-                return [val for subl in result for val in subl if not isinstance(val, Exception)]
+                return [
+                    val
+                    for subl in result
+                    for val in subl
+                    if not isinstance(val, Exception)
+                ]
             return [val for subl in result for val in subl]
 
     def fetch_sync(self) -> List[SpotEntry]:

--- a/empiric-package/empiric/publisher/client.py
+++ b/empiric-package/empiric/publisher/client.py
@@ -47,7 +47,8 @@ class EmpiricPublisherClient(EmpiricClient):
 
     async def fetch(self) -> List[SpotEntry]:
         tasks = []
-        async with aiohttp.ClientSession() as session:
+        timeout = aiohttp.ClientTimeout(total=10)  # 10 seconds per request
+        async with aiohttp.ClientSession(timeout=timeout) as session:
             for fetcher in self.fetchers:
                 data = fetcher.fetch(session)
                 tasks.append(data)

--- a/empiric-package/empiric/publisher/client.py
+++ b/empiric-package/empiric/publisher/client.py
@@ -54,13 +54,6 @@ class EmpiricPublisherClient(EmpiricClient):
                 tasks.append(data)
             result = await asyncio.gather(*tasks, return_exceptions=True)
             if filter_exceptions:
-                for exception in [
-                    val
-                    for subl in result
-                    for val in subl
-                    if isinstance(val, Exception)
-                ]:
-                    log.warn(f'Fetch Error: {exception}')
                 return [
                     val
                     for subl in result

--- a/empiric-package/empiric/publisher/fetchers/cex.py
+++ b/empiric-package/empiric/publisher/fetchers/cex.py
@@ -65,7 +65,7 @@ class CexFetcher(PublisherInterfaceT):
                 logger.debug(f"Skipping CEX for non-spot asset {asset}")
                 continue
             entries.append(asyncio.ensure_future(self._fetch_pair(asset, session)))
-        return await asyncio.gather(*entries)
+        return await asyncio.gather(*entries, return_exceptions=True)
 
     def fetch_sync(self) -> List[Union[SpotEntry, PublisherFetchError]]:
         entries = []

--- a/empiric-package/empiric/publisher/fetchers/coinbase.py
+++ b/empiric-package/empiric/publisher/fetchers/coinbase.py
@@ -119,7 +119,7 @@ class CoinbaseFetcher(PublisherInterfaceT):
                 continue
 
             entries.append(asyncio.ensure_future(self._fetch_pair(asset, session)))
-        return await asyncio.gather(*entries)
+        return await asyncio.gather(*entries, return_exceptions=True)
 
     def fetch_sync(self) -> List[Union[SpotEntry, PublisherFetchError]]:
         entries = []

--- a/empiric-package/empiric/publisher/fetchers/coingecko.py
+++ b/empiric-package/empiric/publisher/fetchers/coingecko.py
@@ -88,7 +88,7 @@ class CoingeckoFetcher(PublisherInterfaceT):
                 logger.debug(f"Skipping {self.SOURCE} for non-spot asset {asset}")
                 continue
             entries.append(asyncio.ensure_future(self._fetch_pair(asset, session)))
-        return await asyncio.gather(*entries)
+        return await asyncio.gather(*entries, return_exceptions=True)
 
     def fetch_sync(self) -> List[SpotEntry]:
         entries = []

--- a/empiric-package/empiric/publisher/fetchers/thegraph.py
+++ b/empiric-package/empiric/publisher/fetchers/thegraph.py
@@ -64,7 +64,7 @@ class TheGraphFetcher(PublisherInterfaceT):
                 logger.debug(f"Skipping The Graph for non-on-chain asset {asset}")
                 continue
             entries.append(asyncio.ensure_future(self._fetch_pair(asset, session)))
-        return await asyncio.gather(*entries)
+        return await asyncio.gather(*entries, return_exceptions=True)
 
     def fetch_sync(self) -> List[GenericEntry]:
         entries = []


### PR DESCRIPTION
We need to make sure that we handle errors in the async threads and proceed with the data successfully gathered after some timeout period. E.g. if the Bitstamp API errors currently, the whole fetching process fails. This fixes a few possible ways that the process can error (404 we already had, this adds a shorter timeout, and json decoding/data parsing errors)