### PR TITLE
Remove legacy sources

### DIFF
--- a/stagecoach/jobs/publishers/examples/publish_all.py
+++ b/stagecoach/jobs/publishers/examples/publish_all.py
@@ -11,8 +11,6 @@ from empiric.publisher.fetchers import (
     CexFetcher,
     CoinbaseFetcher,
     FtxFetcher,
-    GeminiFetcher,
-    TheGraphFetcher,
 )
 
 logger = get_stream_logger()
@@ -34,8 +32,6 @@ async def publish_all(assets):
                 CexFetcher,
                 CoinbaseFetcher,
                 FtxFetcher,
-                GeminiFetcher,
-                TheGraphFetcher,
             )
         ]
     )

--- a/stagecoach/jobs/publishers/publish-all/app.py
+++ b/stagecoach/jobs/publishers/publish-all/app.py
@@ -12,7 +12,6 @@ from empiric.publisher.fetchers import (
     CexFetcher,
     CoinbaseFetcher,
     FtxFetcher,
-    GeminiFetcher,
     TheGraphFetcher,
 )
 
@@ -59,7 +58,6 @@ async def _handler(assets):
                 CexFetcher,
                 CoinbaseFetcher,
                 FtxFetcher,
-                GeminiFetcher,
                 TheGraphFetcher,
             )
         ]


### PR DESCRIPTION
Can drop Gemini because they sign their data themselves & send it directly to our smart contracts now
For the Graph we will be getting this data to L2 via storage proofs shortly (Aave L1 overnight rates)