### PR TITLE
Update IEmpiricOracle and change get_last_checkpoint to get_last_spot_checkpoint

### DIFF
--- a/contracts/starknet/build/Oracle_abi.json
+++ b/contracts/starknet/build/Oracle_abi.json
@@ -913,7 +913,7 @@
     {
         "inputs": [
             {
-                "name": "key",
+                "name": "pair_id",
                 "type": "felt"
             },
             {
@@ -921,7 +921,7 @@
                 "type": "felt"
             }
         ],
-        "name": "get_last_checkpoint_before",
+        "name": "get_last_spot_checkpoint_before",
         "outputs": [
             {
                 "name": "checkpoint",

--- a/contracts/starknet/src/compute_engines/summary_stats/library.cairo
+++ b/contracts/starknet/src/compute_engines/summary_stats/library.cairo
@@ -19,7 +19,9 @@ namespace SummaryStats {
         let (latest_checkpoint_index) = IOracle.get_latest_checkpoint_index(
             contract_address=oracle_address, key=key
         );
-        let (cp, start_index) = IOracle.get_last_checkpoint_before(oracle_address, key, start_tick);
+        let (cp, start_index) = IOracle.get_last_spot_checkpoint_before(
+            oracle_address, key, start_tick
+        );
         with_attr error_message("Not enough data") {
             assert_not_equal(start_index, latest_checkpoint_index);
         }
@@ -46,7 +48,9 @@ namespace SummaryStats {
         let (latest_checkpoint_index) = IOracle.get_latest_checkpoint_index(
             contract_address=oracle_address, key=key
         );
-        let (cp, start_index) = IOracle.get_last_checkpoint_before(oracle_address, key, start_tick);
+        let (cp, start_index) = IOracle.get_last_spot_checkpoint_before(
+            oracle_address, key, start_tick
+        );
 
         with_attr error_message("Not enough data") {
             assert_not_equal(start_index, latest_checkpoint_index);

--- a/contracts/starknet/src/oracle/IEmpiricOracle.cairo
+++ b/contracts/starknet/src/oracle/IEmpiricOracle.cairo
@@ -14,6 +14,13 @@ struct SpotEntry {
     volume: felt,  // Volume aggregated into this market price
 }
 
+struct Checkpoint {
+    timestamp: felt,
+    value: felt,
+    aggregation_mode: felt,
+    num_sources_aggregated: felt,
+}
+
 namespace EmpiricAggregationModes {
     const MEDIAN = 84959893733710;  // str_to_felt("MEDIAN")
 }
@@ -24,18 +31,26 @@ namespace IEmpiricOracle {
     // Getters
     //
 
-    func get_spot_decimals(pair_id: felt) -> (decimals: felt) {
-    }
-
-    func get_spot_entries(pair_id: felt, sources_len: felt, sources: felt*) -> (
-        entries_len: felt, entries: SpotEntry*
+    func get_spot_median(pair_id: felt) -> (
+        price: felt, decimals: felt, last_updated_timestamp: felt, num_sources_aggregated: felt
     ) {
     }
 
-    func get_spot_entry(pair_id: felt, source: felt) -> (entry: SpotEntry) {
+    func get_spot(pair_id: felt, aggregation_mode: felt) -> (
+        price: felt, decimals: felt, last_updated_timestamp: felt, num_sources_aggregated: felt
+    ) {
     }
 
-    func get_spot(pair_id: felt, aggregation_mode: felt) -> (
+    // func get_spot_median_multi
+
+    func get_spot_with_USD_hop(base_currency_id, quote_currency_id, aggregation_mode) -> (
+        price: felt, decimals: felt, last_updated_timestamp: felt, num_sources_aggregated: felt
+    ) {
+    }
+
+    // func get_spot_with_hops
+
+    func get_spot_median_for_sources(pair_id: felt, sources_len: felt, sources: felt*) -> (
         price: felt, decimals: felt, last_updated_timestamp: felt, num_sources_aggregated: felt
     ) {
     }
@@ -45,18 +60,32 @@ namespace IEmpiricOracle {
     ) -> (price: felt, decimals: felt, last_updated_timestamp: felt, num_sources_aggregated: felt) {
     }
 
+    // func get_futures
+
+    func get_spot_entry(pair_id: felt, source: felt) -> (entry: SpotEntry) {
+    }
+
+    func get_spot_entries(pair_id: felt, sources_len: felt, sources: felt*) -> (
+        entries_len: felt, entries: SpotEntry*
+    ) {
+    }
+
     func get_spot_entries_for_sources(pair_id: felt, sources_len: felt, sources: felt*) -> (
         entries_len: felt, entries: SpotEntry*
     ) {
     }
 
-    func get_spot_median(pair_id: felt) -> (
-        price: felt, decimals: felt, last_updated_timestamp: felt, num_sources_aggregated: felt
-    ) {
+    func get_spot_decimals(pair_id: felt) -> (decimals: felt) {
     }
 
-    func get_spot_median_for_sources(pair_id: felt, sources_len: felt, sources: felt*) -> (
-        price: felt, decimals: felt, last_updated_timestamp: felt, num_sources_aggregated: felt
+    // func get_future_entry
+
+    // func get_future_entries
+
+    // func get_future_entries_for_sources
+
+    func get_last_spot_checkpoint_before(pair_id: felt, timestamp: felt) -> (
+        checkpoint: Checkpoint, idx: felt
     ) {
     }
 }

--- a/contracts/starknet/src/oracle/IOracle.cairo
+++ b/contracts/starknet/src/oracle/IOracle.cairo
@@ -133,7 +133,7 @@ namespace IOracle {
     func set_sources_threshold(threshold: felt) {
     }
 
-    func get_last_checkpoint_before(key: felt, timestamp: felt) -> (
+    func get_last_spot_checkpoint_before(pair_id: felt, timestamp: felt) -> (
         checkpoint: Checkpoint, idx: felt
     ) {
     }

--- a/contracts/starknet/src/oracle/Oracle.cairo
+++ b/contracts/starknet/src/oracle/Oracle.cairo
@@ -348,11 +348,11 @@ func set_checkpoints{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check
 }
 
 @view
-func get_last_checkpoint_before{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-    key: felt, timestamp: felt
-) -> (checkpoint: Checkpoint, idx: felt) {
-    let idx = Oracle.find_startpoint(key, timestamp);
-    let (cp) = Oracle.get_checkpoint_by_index(key, idx);
+func get_last_spot_checkpoint_before{
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
+}(pair_id: felt, timestamp: felt) -> (checkpoint: Checkpoint, idx: felt) {
+    let idx = Oracle.find_startpoint(pair_id, timestamp);
+    let (cp) = Oracle.get_checkpoint_by_index(pair_id, idx);
     return (cp, idx);
 }
 

--- a/contracts/starknet/tests/test_compute_engines/test_summary_stats.cairo
+++ b/contracts/starknet/tests/test_compute_engines/test_summary_stats.cairo
@@ -337,10 +337,10 @@ func test_checkpointing{syscall_ptr: felt*, range_check_ptr}() {
     %{ stop_warp = warp(0) %}
     _iter_prices_and_times(0, 10, times_arr, prices_arr);
 
-    let (_cp, _idx) = IOracle.get_last_checkpoint_before(oracle_address, 1, 901);
+    let (_cp, _idx) = IOracle.get_last_spot_checkpoint_before(oracle_address, 1, 901);
     assert _idx = 8;
 
-    let (_cp, _idx) = IOracle.get_last_checkpoint_before(oracle_address, 1, 301);
+    let (_cp, _idx) = IOracle.get_last_spot_checkpoint_before(oracle_address, 1, 301);
     assert _idx = 2;
 
     return ();

--- a/empiric-package/.bumpversion.cfg
+++ b/empiric-package/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.1
+current_version = 1.1.2
 commit = True
 tag = True
 

--- a/empiric-package/empiric/cli/contracts/oracle.py
+++ b/empiric-package/empiric/cli/contracts/oracle.py
@@ -207,7 +207,7 @@ async def get_latest_cp(pair_id: str, config_path: Path = config.DEFAULT_CONFIG)
     client = net.init_empiric_client(config_path)
     latest = await client.oracle.get_latest_checkpoint_index.call(str_to_felt(pair_id))
     typer.echo(f"latest: {latest}")
-    entry = await client.oracle.get_last_checkpoint_before.call(
+    entry = await client.oracle.get_last_spot_checkpoint_before.call(
         str_to_felt(pair_id), 1666197238
     )
     typer.echo(f"cp: {entry}")

--- a/empiric-package/empiric/core/abis/oracle.py
+++ b/empiric-package/empiric/core/abis/oracle.py
@@ -431,7 +431,7 @@ ORACLE_ABI = [
             {"name": "key", "type": "felt"},
             {"name": "timestamp", "type": "felt"},
         ],
-        "name": "get_last_checkpoint_before",
+        "name": "get_last_spot_checkpoint_before",
         "outputs": [
             {"name": "checkpoint", "type": "Checkpoint"},
             {"name": "idx", "type": "felt"},

--- a/empiric-package/empiric/core/abis/oracle.py
+++ b/empiric-package/empiric/core/abis/oracle.py
@@ -330,6 +330,15 @@ ORACLE_ABI = [
     {
         "inputs": [
             {"name": "new_entries_len", "type": "felt"},
+            {"name": "new_entries", "type": "FutureEntry*"},
+        ],
+        "name": "publish_future_entries",
+        "outputs": [],
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {"name": "new_entries_len", "type": "felt"},
             {"name": "new_entries", "type": "SpotEntry*"},
         ],
         "name": "publish_spot_entries",
@@ -428,7 +437,7 @@ ORACLE_ABI = [
     },
     {
         "inputs": [
-            {"name": "key", "type": "felt"},
+            {"name": "pair_id", "type": "felt"},
             {"name": "timestamp", "type": "felt"},
         ],
         "name": "get_last_spot_checkpoint_before",

--- a/empiric-package/setup.cfg
+++ b/empiric-package/setup.cfg
@@ -7,7 +7,7 @@ line-length = 88
 
 [metadata]
 name = empiric-network
-version = 1.1.1
+version = 1.1.2
 author = 42 Labs
 author_email = jonas@42labs.xyz
 description = Core package for rollup-native Empiric Network


### PR DESCRIPTION
IEmpiricOracle.cairo has no Empiric-specific imports which makes it copy-pastable for easy dependency management.
Adding "spot" to the last_checkpiont call makes it forward compatible once we allow for future and options checkpoints