### PR TITLE
Update time buffers for mainnet

### DIFF
--- a/contracts/starknet/lib/time_series/convert.cairo
+++ b/contracts/starknet/lib/time_series/convert.cairo
@@ -94,3 +94,14 @@ func _max{range_check_ptr}(a: felt, b: felt) -> (max_val: felt) {
     }
     return (a,);
 }
+
+// @param a: the first felt
+// @param b: the second felt
+// @return min_val: the smaller felt
+func _min{range_check_ptr}(a: felt, b: felt) -> (min_val: felt) {
+    let a_is_less = is_le(a, b);
+    if (a_is_less == FALSE) {
+        return (b,);
+    }
+    return (a,);
+}

--- a/contracts/starknet/src/oracle/library.cairo
+++ b/contracts/starknet/src/oracle/library.cairo
@@ -21,8 +21,8 @@ from entry.structs import Checkpoint, Currency, GenericEntry, FutureEntry, SpotE
 from publisher_registry.IPublisherRegistry import IPublisherRegistry
 from entry.library import Entries
 
-const BACKWARD_TIMESTAMP_BUFFER = 3600;  // Min difference data timestamp - current block timestamp (60 minutes)
-const FORWARD_TIMESTAMP_BUFFER = 900;  // Max difference data timestamp - current block timestamp (15 minutes)
+const BACKWARD_TIMESTAMP_BUFFER = 7800;  // Min difference data timestamp - current block timestamp (2 hours and 10 minutes)
+const FORWARD_TIMESTAMP_BUFFER = 7800;  // Max difference data timestamp - current block timestamp (2 hours and 10 minutes)
 const BOTH_TRUE = 2;
 const USD_CURRENCY_ID = 5591876;  // str_to_felt("USD")
 

--- a/tests/test_oracle.py
+++ b/tests/test_oracle.py
@@ -1053,10 +1053,7 @@ async def test_ignore_stale_entries(
     )
 
     # Advance time by TIMESTAMP_BUFFER
-    admin_account.state.state.block_info = BlockInfo.create_for_testing(
-        admin_account.state.state.block_info.block_number,
-        admin_account.state.state.block_info.block_timestamp + TIMESTAMP_BUFFER,
-    )
+    advance_time(admin_account.state.state, TIMESTAMP_BUFFER)
 
     second_entry = SpotEntry(
         pair_id=pair_id,

--- a/tests/test_oracle.py
+++ b/tests/test_oracle.py
@@ -979,40 +979,6 @@ async def test_real_data(
 
 
 @pytest.mark.asyncio
-async def test_ignore_future_entry(
-    initialized_contracts,
-    source,
-    publisher,
-    publisher_signer,
-):
-    publisher_account = initialized_contracts["publisher_account"]
-    oracle_proxy = initialized_contracts["oracle_proxy"]
-    pair_id = str_to_felt("ETH/USD")
-
-    entry = SpotEntry(
-        pair_id=pair_id,
-        price=3,
-        timestamp=STARKNET_STARTING_TIMESTAMP + TIMESTAMP_BUFFER + 1,
-        source=source,
-        publisher=publisher,
-    )
-
-    try:
-        await publisher_signer.send_transaction(
-            publisher_account,
-            oracle_proxy.contract_address,
-            "publish_spot_entry",
-            entry.to_tuple(),
-        )
-
-        raise Exception(
-            "Transaction to submit price too far in the future succeeded, but should not have."
-        )
-    except StarkException:
-        pass
-
-
-@pytest.mark.asyncio
 async def test_ignore_stale_entries(
     initialized_contracts, admin_signer, source, publisher, publisher_signer
 ):


### PR DESCRIPTION
On mainnet blocks can be up to 2 hours long so we need the time window to be 2 hours.
Additionally, the timestamp is currently set at the end of the block, but in the near future StarkWare plans to have the block timestamp be the beginning of the block, so we need the backward and forward window to be large in the interim