### PR TITLE
Improve coinbase fetcher by using the exchange endpoint not signed data

### DIFF
--- a/empiric-package/.bumpversion.cfg
+++ b/empiric-package/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.0
+current_version = 1.1.1
 commit = True
 tag = True
 

--- a/empiric-package/empiric/publisher/fetchers/coinbase.py
+++ b/empiric-package/empiric/publisher/fetchers/coinbase.py
@@ -1,10 +1,6 @@
 import asyncio
-import base64
-import datetime
-import hmac
 import logging
-import os
-from hashlib import sha256
+import time
 from typing import List, Union
 
 import requests
@@ -18,94 +14,30 @@ logger = logging.getLogger(__name__)
 
 
 class CoinbaseFetcher(PublisherInterfaceT):
-    BASE_URL: str = "https://api.exchange.coinbase.com"
+    BASE_URL: str = "https://api.coinbase.com/v2/exchange-rates?currency="
     SOURCE: str = "COINBASE"
-    REQUEST_PATH = "/oracle"
-    METHOD = "GET"
 
-    COINBASE_API_SECRET: str
-    COINBASE_API_KEY: str
-    COINBASE_API_PASSPHRASE: str
     publisher: str
 
     def __init__(self, assets: List[EmpiricAsset], publisher):
-        # TODO (rlkelly): migrate from using environment variables
-        self.COINBASE_API_SECRET = os.environ.get("COINBASE_API_SECRET")
-        self.COINBASE_API_KEY = os.environ.get("COINBASE_API_KEY")
-        self.COINBASE_API_PASSPHRASE = os.environ.get("COINBASE_API_PASSPHRASE")
-
         self.assets = assets
         self.publisher = publisher
 
     async def _fetch_pair(
         self, asset: EmpiricSpotAsset, session: ClientSession
     ) -> Union[SpotEntry, PublisherFetchError]:
-        pair = asset["pair"]
-        if pair[1] != "USD":
-            return PublisherFetchError(
-                f"Unable to fetch Coinbase price for non-USD denomination {pair[1]}"
-            )
+        currency = asset["pair"][1]
 
-        request_timestamp = str(
-            int(
-                datetime.datetime.now(datetime.timezone.utc)
-                .replace(tzinfo=datetime.timezone.utc)
-                .timestamp()
-            )
-        )
-
-        signature = hmac.new(
-            base64.b64decode(self.COINBASE_API_SECRET),
-            (request_timestamp + self.METHOD + self.REQUEST_PATH).encode("ascii"),
-            sha256,
-        )
-
-        headers = {
-            "Accept": "application/json",
-            "CB-ACCESS-KEY": self.COINBASE_API_KEY,
-            "CB-ACCESS-SIGN": base64.b64encode(signature.digest()).decode("utf8"),
-            "CB-ACCESS-TIMESTAMP": request_timestamp,
-            "CB-ACCESS-PASSPHRASE": self.COINBASE_API_PASSPHRASE,
-        }
-
-        async with session.get(
-            self.BASE_URL + self.REQUEST_PATH, headers=headers
-        ) as resp:
+        async with session.get(self.BASE_URL + currency) as resp:
             result = await resp.json()
             return self._construct(asset, result)
 
     def _fetch_pair_sync(
         self, asset: EmpiricSpotAsset
     ) -> Union[SpotEntry, PublisherFetchError]:
-        pair = asset["pair"]
-        if pair[1] != "USD":
-            return PublisherFetchError(
-                f"Unable to fetch Coinbase price for non-USD denomination {pair[1]}"
-            )
+        currency = asset["pair"][1]
 
-        request_timestamp = str(
-            int(
-                datetime.datetime.now(datetime.timezone.utc)
-                .replace(tzinfo=datetime.timezone.utc)
-                .timestamp()
-            )
-        )
-
-        signature = hmac.new(
-            base64.b64decode(self.COINBASE_API_SECRET),
-            (request_timestamp + self.METHOD + self.REQUEST_PATH).encode("ascii"),
-            sha256,
-        )
-
-        headers = {
-            "Accept": "application/json",
-            "CB-ACCESS-KEY": self.COINBASE_API_KEY,
-            "CB-ACCESS-SIGN": base64.b64encode(signature.digest()),
-            "CB-ACCESS-TIMESTAMP": request_timestamp,
-            "CB-ACCESS-PASSPHRASE": self.COINBASE_API_PASSPHRASE,
-        }
-
-        resp = requests.get(self.BASE_URL + self.REQUEST_PATH, headers=headers)
+        resp = requests.get(self.BASE_URL + currency)
         resp.raise_for_status()
 
         result = resp.json()
@@ -137,11 +69,11 @@ class CoinbaseFetcher(PublisherInterfaceT):
         pair = asset["pair"]
         pair_id = currency_pair_to_pair_id(*pair)
 
-        if pair[0] in result["prices"]:
-            price = float(result["prices"][pair[0]])
+        if pair[0] in result["data"]["rates"]:
+            rate = float(result["data"]["rates"][pair[0]])
+            price = 1 / rate
             price_int = int(price * (10 ** asset["decimals"]))
-
-            timestamp = int(result["timestamp"])
+            timestamp = int(time.time())
 
             logger.info(f"Fetched price {price} for {pair_id} from Coinbase")
 

--- a/empiric-package/setup.cfg
+++ b/empiric-package/setup.cfg
@@ -7,7 +7,7 @@ line-length = 88
 
 [metadata]
 name = empiric-network
-version = 1.1.0
+version = 1.1.1
 author = 42 Labs
 author_email = jonas@42labs.xyz
 description = Core package for rollup-native Empiric Network


### PR DESCRIPTION
The old API endpoint we were using had very limited data (see overview here: https://www.notion.so/42labs-xyz/Spot-Data-Coverage-62fe92e077f6416d9285bdeca452ab6b)

This uses the exchange API endpoint which has more data (open oracle will continue to use the other endpoint which has signed data).